### PR TITLE
Create manifest.json for compatibility with Home Assistant >= 0.92

### DIFF
--- a/custom_components/yeelight_bt/manifest.json
+++ b/custom_components/yeelight_bt/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "yeelight_bt",
+  "name": "yeelight_bt - Originally made by rytilahti, modded by hcoohb.",
+  "documentation": "https://github.com/hcoohb/python-yeelightbt",
+  "dependencies": [],
+  "codeowners": [],
+  "requirements": []
+}


### PR DESCRIPTION
Starting with 0.92.0, HA requires a manifest.json and __init__.py .